### PR TITLE
[Feature] 폰트관리를 위한 GLFont 구현 및 적용

### DIFF
--- a/GraceLog.xcodeproj/project.pbxproj
+++ b/GraceLog.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		02F0DA512DDEAED900CD036A /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F0DA502DDEAED900CD036A /* AuthManager.swift */; };
 		6D6D359847E48286C67E16F7 /* Pods_GraceLogUseCaseTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D415D287B3EAEECA4BE40BB /* Pods_GraceLogUseCaseTests.framework */; };
 		704815772DFEC53A009ECDBD /* GLUnderlineSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704815762DFEC53A009ECDBD /* GLUnderlineSegmentedControl.swift */; };
+		7048157A2DFFF362009ECDBD /* FontStylable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704815792DFFF362009ECDBD /* FontStylable.swift */; };
+		7048157C2DFFF570009ECDBD /* GLFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7048157B2DFFF570009ECDBD /* GLFont.swift */; };
+		7048157E2DFFF95B009ECDBD /* FontName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7048157D2DFFF95B009ECDBD /* FontName.swift */; };
 		75248638A478EB9521F76504 /* Pods_GraceLog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC27041694929DC3D121EF0C /* Pods_GraceLog.framework */; };
 		A88BF65DF907D86788F86BF8 /* Pods_GraceLog_GraceLogUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92AAD74E157DB380B9B4192E /* Pods_GraceLog_GraceLogUITests.framework */; };
 		DE069B982D53A855007C2066 /* DiaryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE069B972D53A855007C2066 /* DiaryCoordinator.swift */; };
@@ -201,6 +204,9 @@
 		3772E15DC148101F5890C6F5 /* Pods-GraceLog.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLog.release.xcconfig"; path = "Target Support Files/Pods-GraceLog/Pods-GraceLog.release.xcconfig"; sourceTree = "<group>"; };
 		45FB5606D88433D808BF0656 /* Pods-GraceLogTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLogTests.debug.xcconfig"; path = "Target Support Files/Pods-GraceLogTests/Pods-GraceLogTests.debug.xcconfig"; sourceTree = "<group>"; };
 		704815762DFEC53A009ECDBD /* GLUnderlineSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GLUnderlineSegmentedControl.swift; sourceTree = "<group>"; };
+		704815792DFFF362009ECDBD /* FontStylable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStylable.swift; sourceTree = "<group>"; };
+		7048157B2DFFF570009ECDBD /* GLFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GLFont.swift; sourceTree = "<group>"; };
+		7048157D2DFFF95B009ECDBD /* FontName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontName.swift; sourceTree = "<group>"; };
 		7D415D287B3EAEECA4BE40BB /* Pods_GraceLogUseCaseTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GraceLogUseCaseTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		87E14D79ABA16C7A19244077 /* Pods-GraceLogTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLogTests.release.xcconfig"; path = "Target Support Files/Pods-GraceLogTests/Pods-GraceLogTests.release.xcconfig"; sourceTree = "<group>"; };
 		8BC9F644955C12A97595F5EF /* Pods-GraceLogUseCaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GraceLogUseCaseTests.debug.xcconfig"; path = "Target Support Files/Pods-GraceLogUseCaseTests/Pods-GraceLogUseCaseTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -541,6 +547,16 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		704815782DFFF2B5009ECDBD /* Font */ = {
+			isa = PBXGroup;
+			children = (
+				704815792DFFF362009ECDBD /* FontStylable.swift */,
+				7048157B2DFFF570009ECDBD /* GLFont.swift */,
+				7048157D2DFFF95B009ECDBD /* FontName.swift */,
+			);
+			path = Font;
+			sourceTree = "<group>";
+		};
 		DE069B922D53A708007C2066 /* DiaryScene */ = {
 			isa = PBXGroup;
 			children = (
@@ -836,6 +852,7 @@
 		DE3BFCC22D043D200076426D /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				704815782DFFF2B5009ECDBD /* Font */,
 				026656A92DE7E9BD00541D96 /* UI */,
 				02F0DA4F2DDEAECC00CD036A /* Manager */,
 				DE2700472D1F9E56005C9DCF /* Extension */,
@@ -1455,6 +1472,7 @@
 				DEA04FA72D69A8C000BA978A /* String+Extension.swift in Sources */,
 				DE58FEB32D04284D008CADCD /* SceneDelegate.swift in Sources */,
 				DEEFEACA2D29270500699692 /* GraceLogUser.swift in Sources */,
+				7048157E2DFFF95B009ECDBD /* FontName.swift in Sources */,
 				DE9A1FD02D6C87E60044F655 /* HomeCommunityDateHeaderView.swift in Sources */,
 				DE9A1FC62D69D62E0044F655 /* CommunityTableViewCell.swift in Sources */,
 				DED558962DBE576A00137B10 /* Const.swift in Sources */,
@@ -1486,11 +1504,13 @@
 				02DC29882DDC29C000662D8A /* MyInfoTableViewCell.swift in Sources */,
 				02DC29892DDC29C000662D8A /* MyInfoViewController.swift in Sources */,
 				02DC298A2DDC29C000662D8A /* ProfileEditFieldView.swift in Sources */,
+				7048157A2DFFF362009ECDBD /* FontStylable.swift in Sources */,
 				02DC298B2DDC29C000662D8A /* MyInfoButtonTableViewCell.swift in Sources */,
 				02DC298C2DDC29C000662D8A /* MyInfoDataSource.swift in Sources */,
 				02DC298D2DDC29C000662D8A /* ProfileTableViewCell.swift in Sources */,
 				DE9A1FF02D7C05720044F655 /* CommunityDiaryDTO.swift in Sources */,
 				DED558842DBE1E4000137B10 /* GraceLogResponseDTO.swift in Sources */,
+				7048157C2DFFF570009ECDBD /* GLFont.swift in Sources */,
 				DE9A1FF82D7C08070044F655 /* DefaultHomeUseCase.swift in Sources */,
 				DE069B9C2D5711D3007C2066 /* HomeNextViewController.swift in Sources */,
 				DE9A1FEE2D7C05240044F655 /* HomeCommunityContentDTO.swift in Sources */,

--- a/GraceLog/Source/Presentation/Common/Coordinator/GraceLogAppCoordinator.swift
+++ b/GraceLog/Source/Presentation/Common/Coordinator/GraceLogAppCoordinator.swift
@@ -78,10 +78,10 @@ final class GraceLogAppCoordinator: Coordinator {
         
         let itemAppearance = UITabBarItemAppearance()
         itemAppearance.normal.titleTextAttributes = [
-            .font: UIFont(name: "Pretendard-Medium", size: 10) ?? .systemFont(ofSize: 10)
+            .font: GLFont.medium10.font
         ]
         itemAppearance.selected.titleTextAttributes = [
-            .font: UIFont(name: "Pretendard-Medium", size: 10) ?? .systemFont(ofSize: 10)
+            .font: GLFont.medium10.font
         ]
         
         appearance.stackedLayoutAppearance = itemAppearance

--- a/GraceLog/Source/Presentation/Common/View/CommonButtonTableViewCell.swift
+++ b/GraceLog/Source/Presentation/Common/View/CommonButtonTableViewCell.swift
@@ -17,7 +17,7 @@ final class CommonButtonTableViewCell: UITableViewCell {
         $0.layer.cornerRadius = 10
         $0.backgroundColor = .themeColor
         $0.setTitleColor(.white, for: .normal)
-        $0.titleLabel?.font = UIFont(name: "Pretendard-ExtraBold", size: 18)
+        $0.titleLabel?.font = GLFont.extraBold18.font
     }
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/GraceLog/Source/Presentation/Common/View/CommonSectionWithDescHeaderView.swift
+++ b/GraceLog/Source/Presentation/Common/View/CommonSectionWithDescHeaderView.swift
@@ -14,12 +14,12 @@ final class CommonSectionWithDescHeaderView: UITableViewHeaderFooterView {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Bold", size: 14)
+        $0.font = GLFont.bold14.font
     }
     
     private let descLabel = UILabel().then {
         $0.textColor = .gray200
-        $0.font = UIFont(name: "Pretendard-Regular", size: 12)
+        $0.font = GLFont.regular12.font
     }
     
     override init(reuseIdentifier: String?) {

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryAddImageCollectionViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryAddImageCollectionViewCell.swift
@@ -31,7 +31,7 @@ final class DiaryAddImageCollectionViewCell: UICollectionViewCell {
     
     private let countLabel = UILabel().then {
         $0.textColor = .gray200
-        $0.font = UIFont(name: "Pretendard-Regular", size: 10)
+        $0.font = GLFont.regular10.font
         $0.textAlignment = .center
     }
     

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryDescriptionTableViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryDescriptionTableViewCell.swift
@@ -21,7 +21,7 @@ final class DiaryDescriptionTableViewCell: UITableViewCell {
     
     private let descriptionTextView = UITextView().then {
         $0.backgroundColor = .white
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textColor = .black
         $0.placeholder = "오늘은 하나님께 어떤 점이 감사했나요?"
         $0.placeholderColor = .gray200
@@ -34,7 +34,7 @@ final class DiaryDescriptionTableViewCell: UITableViewCell {
     }
     
     private let countLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textColor = .gray200
         $0.text = "0/500"
         $0.textAlignment = .right

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryImageCollectionViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryImageCollectionViewCell.swift
@@ -33,7 +33,7 @@ final class DiaryImageCollectionViewCell: UICollectionViewCell {
         $0.text = "대표 사진"
         $0.textColor = .white
         $0.textAlignment = .center
-        $0.font = UIFont(name: "Pretendard-Regular", size: 10)
+        $0.font = GLFont.regular10.font
         $0.clipsToBounds = true
         $0.isHidden = true
     }

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryKeywordCollectionViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryKeywordCollectionViewCell.swift
@@ -13,7 +13,7 @@ final class DiaryKeywordCollectionViewCell: UICollectionViewCell {
     static let identifier = "DiaryKeywordCollectionViewCell"
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 14)
+        $0.font = GLFont.bold14.font
         $0.textColor = .gray200
         $0.textAlignment = .center
     }

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiarySettingsTableViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiarySettingsTableViewCell.swift
@@ -20,7 +20,7 @@ final class DiarySettingsTableViewCell: UITableViewCell {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .black
-        $0.font = UIFont(name: "Pretendard-Regular", size: 16)
+        $0.font = GLFont.regular16.font
         $0.text = "추가 설정"
     }
     

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiarySwitchTableViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiarySwitchTableViewCell.swift
@@ -18,7 +18,7 @@ final class DiarySwitchTableViewCell: UITableViewCell {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .black
-        $0.font = UIFont(name: "Pretendard-Regular", size: 16)
+        $0.font = GLFont.regular16.font
     }
     
     private let shareSwitch = UISwitch().then {

--- a/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryTitleTableViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Diary/DiaryTitleTableViewCell.swift
@@ -22,7 +22,7 @@ final class DiaryTitleTableViewCell: UITableViewCell {
     private let titleField = UITextField().then {
         $0.setHeight(40)
         $0.backgroundColor = UIColor(white: 1, alpha: 0.1)
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textColor = .black
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 17, height: $0.frame.height))
         $0.leftViewMode = .always
@@ -33,7 +33,7 @@ final class DiaryTitleTableViewCell: UITableViewCell {
     }
     
     private let countLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textColor = .gray200
         $0.text = "0/30"
         $0.textAlignment = .center

--- a/GraceLog/Source/Presentation/DiaryScene/View/Settings/DiaryAdditionalSettingsTableViewCell.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/View/Settings/DiaryAdditionalSettingsTableViewCell.swift
@@ -17,12 +17,12 @@ final class DiaryAdditionalSettingsTableViewCell: UITableViewCell {
     var disposeBag = DisposeBag()
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 16)
+        $0.font = GLFont.regular16.font
         $0.textColor = .black
     }
     
     private let descLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 12)
+        $0.font = GLFont.regular12.font
         $0.textColor = .gray200
     }
     

--- a/GraceLog/Source/Presentation/DiaryScene/ViewController/DiaryAdditionalSettingsViewController.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/ViewController/DiaryAdditionalSettingsViewController.swift
@@ -73,7 +73,7 @@ extension DiaryAdditionalSettingsViewController: UITableViewDelegate {
         }
         
         let sectionTitle = dataSource.sectionModels[section].header
-        headerView.setTitle(sectionTitle, font: UIFont(name: "Pretendard-Bold", size: 16) ?? .systemFont(ofSize: 16, weight: .bold))
+        headerView.setTitle(sectionTitle, font: GLFont.bold16.font)
         headerView.updateTopOffset(section == 0 ? 4 : 20)
         
         return headerView

--- a/GraceLog/Source/Presentation/DiaryScene/ViewController/DiaryViewController.swift
+++ b/GraceLog/Source/Presentation/DiaryScene/ViewController/DiaryViewController.swift
@@ -42,7 +42,7 @@ final class DiaryViewController: UIViewController, View {
         $0.backgroundColor = .themeColor
         $0.setTitle("공유하기", for: .normal)
         $0.setTitleColor(.white, for: .normal)
-        $0.titleLabel?.font = UIFont(name: "Pretendard-ExtraBold", size: 18)
+        $0.titleLabel?.font = GLFont.extraBold18.font
         $0.layer.cornerRadius = 10
         $0.clipsToBounds = true
     }
@@ -225,7 +225,7 @@ extension DiaryViewController: UITableViewDelegate {
         case .title, .description, .shareOptions:
             if let title = dataSource[section].title {
                 let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: CommonSectionHeaderView.identifier) as? CommonSectionHeaderView
-                headerView?.setTitle(title, font: UIFont(name: "Pretendard-Bold", size: 14)!)
+                headerView?.setTitle(title, font: GLFont.bold14.font)
                 return headerView
             }
         case .keyword:

--- a/GraceLog/Source/Presentation/HomeScene/View/CommunityButton.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/CommunityButton.swift
@@ -30,7 +30,7 @@ final class CommunityButton: UIView {
     }
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 11)
+        $0.font = GLFont.regular11.font
         $0.textAlignment = .center
         $0.textColor = .graceGray
     }

--- a/GraceLog/Source/Presentation/HomeScene/View/DiaryCardView.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/DiaryCardView.swift
@@ -36,13 +36,13 @@ final class DiaryCardView: UIView {
     }
     
     private let dateDescLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Light", size: 11)
+        $0.font = GLFont.light11.font
         $0.textColor = .white
     }
     
     private lazy var descLabel = UILabel().then {
         $0.textColor = .white
-        $0.font = UIFont(name: "Pretendard-Regular", size: 18)
+        $0.font = GLFont.regular18.font
         $0.numberOfLines = 0
     }
     
@@ -68,7 +68,7 @@ final class DiaryCardView: UIView {
         imageView.image = item.image
         
         titleLabel.text = item.title
-        titleLabel.font = UIFont(name: "Pretendard-Bold", size: style == .latest ? 14 : 20)
+        titleLabel.font = style == .latest ? GLFont.bold14.font : GLFont.bold20.font
         
         dateDescLabel.text = item.dateDesc
         

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityDateHeaderView.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityDateHeaderView.swift
@@ -13,7 +13,7 @@ final class HomeCommunityDateHeaderView: UITableViewHeaderFooterView {
     static let identifier = "HomeCommunityDateHeaderView"
     
     private let dateLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 12)
+        $0.font = GLFont.regular12.font
         $0.textColor = .themeColor
     }
     

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityMyTableViewCell.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityMyTableViewCell.swift
@@ -21,7 +21,7 @@ final class HomeCommunityMyTableViewCell: UITableViewCell {
     }
     
     private let usernameLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 12)
+        $0.font = GLFont.bold12.font
         $0.textColor = .graceGray
     }
     
@@ -39,13 +39,13 @@ final class HomeCommunityMyTableViewCell: UITableViewCell {
     private let overlayView = UIView()
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 20)
+        $0.font = GLFont.bold20.font
         $0.textColor = .white
         $0.numberOfLines = 0
     }
     
     private let hashtagsLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Light", size: 11)
+        $0.font = GLFont.light11.font
         $0.textColor = .white
     }
     
@@ -57,7 +57,7 @@ final class HomeCommunityMyTableViewCell: UITableViewCell {
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = UIFont(name: "Pretendard-Bold", size: 14)
+            outgoing.font = GLFont.bold14.font
             outgoing.foregroundColor = .gray100
             return outgoing
         }
@@ -73,7 +73,7 @@ final class HomeCommunityMyTableViewCell: UITableViewCell {
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = UIFont(name: "Pretendard-Bold", size: 14)
+            outgoing.font = GLFont.bold14.font
             outgoing.foregroundColor = .gray
             return outgoing
         }

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityUserTableViewCell.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeCommunityUserTableViewCell.swift
@@ -21,7 +21,7 @@ final class HomeCommunityUserTableViewCell: UITableViewCell {
     }
     
     private let usernameLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 12)
+        $0.font = GLFont.bold12.font
         $0.textColor = .graceGray
     }
     
@@ -39,13 +39,13 @@ final class HomeCommunityUserTableViewCell: UITableViewCell {
     private let overlayView = UIView()
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 20)
+        $0.font = GLFont.bold20.font
         $0.textColor = .white
         $0.numberOfLines = 0
     }
     
     private let hashtagsLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Light", size: 11)
+        $0.font = GLFont.light11.font
         $0.textColor = .white
     }
     
@@ -57,7 +57,7 @@ final class HomeCommunityUserTableViewCell: UITableViewCell {
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = UIFont(name: "Pretendard-Bold", size: 14)
+            outgoing.font = GLFont.bold14.font
             outgoing.foregroundColor = .gray100
             return outgoing
         }
@@ -73,7 +73,7 @@ final class HomeCommunityUserTableViewCell: UITableViewCell {
         config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = UIFont(name: "Pretendard-Bold", size: 14)
+            outgoing.font = GLFont.bold14.font
             outgoing.foregroundColor = .gray
             return outgoing
         }

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeDiaryTableViewCell.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeDiaryTableViewCell.swift
@@ -18,7 +18,7 @@ final class HomeDiaryTableViewCell: UITableViewCell {
     }
     
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 12)
+        $0.font = GLFont.bold12.font
         $0.textColor = .themeColor
     }
     

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeNavBarTableViewHeader.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeNavBarTableViewHeader.swift
@@ -16,7 +16,7 @@ final class HomeNavBarTableViewHeader: UIView {
     private let disposeBag = DisposeBag()
     
     private let userButton = UIButton().then {
-        $0.titleLabel?.font = UIFont(name: "Pretendard-Bold", size: 18)
+        $0.titleLabel?.font = GLFont.bold18.font
         $0.setTitle("승렬", for: .normal)
         $0.setTitleColor(.themeColor, for: .normal)
     }
@@ -27,7 +27,7 @@ final class HomeNavBarTableViewHeader: UIView {
     }
     
     private let groupButton = UIButton().then {
-        $0.titleLabel?.font = UIFont(name: "Pretendard-Bold", size: 18)
+        $0.titleLabel?.font = GLFont.bold18.font
         $0.setTitle("공동체", for: .normal)
         $0.setTitleColor(.black, for: .normal)
     }

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeRecommendTableViewCell.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeRecommendTableViewCell.swift
@@ -13,7 +13,7 @@ final class HomeRecommendTableViewCell: UITableViewCell {
     static let identifier = "HomeRecommendTableViewCell"
     
     private let contentTitleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Bold", size: 14)
+        $0.font = GLFont.bold14.font
         $0.textColor = .graceGray
     }
     

--- a/GraceLog/Source/Presentation/HomeScene/View/HomeTableViewHeader.swift
+++ b/GraceLog/Source/Presentation/HomeScene/View/HomeTableViewHeader.swift
@@ -14,18 +14,18 @@ final class HomeTableViewHeader: UITableViewHeaderFooterView {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Bold", size: 12)
+        $0.font = GLFont.bold12.font
     }
     
     private let descLabel = UILabel().then {
         $0.textColor = .graceGray
-        $0.font = UIFont(name: "Pretendard-Regular", size: 24)
+        $0.font = GLFont.regular24.font
         $0.numberOfLines = 4
     }
     
     private let paragraphLabel = UILabel().then {
         $0.textColor = .graceGray
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
     }
     
     private let stackView = UIStackView().then {

--- a/GraceLog/Source/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/GraceLog/Source/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -32,8 +32,8 @@ final class HomeViewController: GraceLogBaseViewController, View {
         $0.selectedSegmentIndex = 0
         
         // TODO: - 폰트 재작업 필요
-        $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: UIFont(name: "Pretendard-Bold", size: 18)!], for: .normal)
-        $0.setTitleTextAttributes([.foregroundColor: UIColor.themeColor, .font: UIFont(name: "Pretendard-Bold", size: 18)!], for: .selected)
+        $0.setTitleTextAttributes([.foregroundColor: UIColor.black, .font: GLFont.bold18.font], for: .normal)
+        $0.setTitleTextAttributes([.foregroundColor: UIColor.themeColor, .font: GLFont.bold18.font], for: .selected)
     }
     private lazy var tableView = UITableView(frame: .zero, style: .grouped).then {
         $0.backgroundColor = UIColor(hex: 0xF4F4F4)

--- a/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoButtonTableViewCell.swift
+++ b/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoButtonTableViewCell.swift
@@ -14,7 +14,7 @@ final class MyInfoButtonTableViewCell: UITableViewCell {
     
     private let button = UIButton().then {
         $0.backgroundColor = .white
-        $0.titleLabel?.font = UIFont(name: "Pretendard-Regular", size: 15)
+        $0.titleLabel?.font = GLFont.regular15.font
         $0.titleLabel?.textAlignment = .center
     }
     

--- a/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoSectionHeaderView.swift
+++ b/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoSectionHeaderView.swift
@@ -14,7 +14,7 @@ final class MyInfoSectionHeaderView: UITableViewHeaderFooterView {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Bold", size: 12)
+        $0.font = GLFont.bold12.font
     }
     
     override init(reuseIdentifier: String?) {

--- a/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoTableViewCell.swift
+++ b/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/MyInfoTableViewCell.swift
@@ -18,7 +18,7 @@ final class MyInfoTableViewCell: UITableViewCell {
     
     private let titleLabel = UILabel().then {
         $0.textColor = .black
-        $0.font = UIFont(name: "Pretendard-Regular", size: 15)
+        $0.font = GLFont.regular15.font
     }
     
     private let disclosureView = UIImageView().then {

--- a/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/ProfileTableViewCell.swift
+++ b/GraceLog/Source/Presentation/MyInfoScene/View/MyInfo/ProfileTableViewCell.swift
@@ -21,14 +21,14 @@ final class ProfileTableViewCell: UITableViewCell {
     
     private let nameLabel = UILabel().then {
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Bold", size: 20)
+        $0.font = GLFont.bold20.font
         $0.textAlignment = .center
         $0.text = AuthManager.shared.getUser()?.name
     }
     
     private let emailLabel = UILabel().then {
         $0.textColor = .graceGray
-        $0.font = UIFont(name: "Pretendard-Regular", size: 12)
+        $0.font = GLFont.regular12.font
         $0.textAlignment = .center
         $0.text = AuthManager.shared.getUser()?.email
     }

--- a/GraceLog/Source/Presentation/MyInfoScene/View/ProfileEdit/ProfileEditFieldView.swift
+++ b/GraceLog/Source/Presentation/MyInfoScene/View/ProfileEdit/ProfileEditFieldView.swift
@@ -13,12 +13,12 @@ import RxCocoa
 
 final class ProfileEditFieldView: UIView {
     private let titleLabel = UILabel().then {
-        $0.font = UIFont(name: "Pretendard-Regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textColor = .gray200
     }
     
     let infoField = UITextField().then {
-        $0.font = UIFont(name: "Pretendard-SemiBold", size: 16)
+        $0.font = GLFont.semiBold16.font
         $0.textColor = .black
     }
     
@@ -63,7 +63,7 @@ final class ProfileEditFieldView: UIView {
         titleLabel.text = title
         infoField.attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [
             .foregroundColor: UIColor.gray200,
-            .font: UIFont(name: "Pretendard-Regular", size: 16) ?? UIFont.systemFont(ofSize: 16)
+            .font: GLFont.regular16.font
         ])
     }
 }

--- a/GraceLog/Source/Presentation/SignInScene/ViewController/SignInViewController.swift
+++ b/GraceLog/Source/Presentation/SignInScene/ViewController/SignInViewController.swift
@@ -30,7 +30,7 @@ final class SignInViewController: UIViewController {
     private let sloganLabel = UILabel().then {
         $0.text = "감사가 채우는 하루"
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Regular", size: 24)
+        $0.font = GLFont.regular24.font
     }
     
     private let logoImgView = UIImageView().then {
@@ -40,7 +40,7 @@ final class SignInViewController: UIViewController {
     private let startLabel = UILabel().then {
         $0.text = "시작하기"
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-regular", size: 14)
+        $0.font = GLFont.regular14.font
         $0.textAlignment = .center
         $0.setDimensions(width: 74, height: 38)
     }
@@ -73,7 +73,7 @@ final class SignInViewController: UIViewController {
     private let copyrightLabel = UILabel().then {
         $0.text = "Copyright Ⓒ 에끌레시아 All Rights Reserved."
         $0.textColor = .themeColor
-        $0.font = UIFont(name: "Pretendard-Regular", size: 12)
+        $0.font = GLFont.regular12.font
     }
     
     private let activityIndicator = NVActivityIndicatorView(frame: .zero, type: .ballSpinFadeLoader, color: .black, padding: 0).then {

--- a/GraceLog/Source/Util/Extension/String+Extension.swift
+++ b/GraceLog/Source/Util/Extension/String+Extension.swift
@@ -9,10 +9,8 @@ import UIKit
 
 extension String {
     func toDiaryDateAttributedString(
-        regularFont: String = "Pretendard-Regular",
-        boldFont: String = "Pretendard-Bold",
-        regularSize: CGFloat = 12,
-        boldSize: CGFloat = 15,
+        regularFont: UIFont = GLFont.regular12.font,
+        boldFont: UIFont = GLFont.bold15.font,
         color: UIColor = .themeColor
     ) -> NSAttributedString {
         let components = self.components(separatedBy: "\n")
@@ -23,7 +21,7 @@ extension String {
         let part1 = NSAttributedString(
             string: components[0] + "\n",
             attributes: [
-                .font: UIFont(name: regularFont, size: regularSize) ?? .systemFont(ofSize: regularSize),
+                .font: regularFont,
                 .foregroundColor: color
             ]
         )
@@ -31,7 +29,7 @@ extension String {
         let part2 = NSAttributedString(
             string: components[1],
             attributes: [
-                .font: UIFont(name: boldFont, size: boldSize) ?? .systemFont(ofSize: boldSize, weight: .bold),
+                .font: boldFont,
                 .foregroundColor: color
             ]
         )

--- a/GraceLog/Source/Util/Font/FontName.swift
+++ b/GraceLog/Source/Util/Font/FontName.swift
@@ -1,0 +1,44 @@
+//
+//  FontName.swift
+//  GraceLog
+//
+//  Created by 이건준 on 6/16/25.
+//
+
+import UIKit
+
+enum FontName: String {
+    case pretendard = "Pretendard"
+}
+
+enum FontStyle: String {
+    case black = "Black"
+    case bold = "Bold"
+    case extraBold = "ExtraBold"
+    case extraLight = "ExtraLight"
+    case light = "Light"
+    case medium = "Medium"
+    case regular = "Regular"
+    case semiBold = "SemiBold"
+    case thin = "Thin"
+}
+
+extension UIFont {
+    /**
+     미리 정의된 `FontName` `FontStyle` 열거형을 사용해 원하는 폰트를 가져온다
+     - Parameters:
+        - font: 폰트 종류  (*i.e.* Pretendard, Osward)
+        - style: 폰트 스타일 (*i.e* regular, semibold)
+        - size: 폰트 크기
+     - Returns: {font}-{style} 이름의 폰트가 있는 경우 해당 폰트 반환, 폰트가 없는 경우 기본 시스템 폰트 반환
+     */
+    static func customFont(font: FontName, style: FontStyle, size: CGFloat) -> UIFont {
+        
+        let customFontName: String = "\(font.rawValue)-\(style.rawValue)"
+        guard let font = UIFont(name: customFontName, size: size) else {
+            return UIFont.systemFont(ofSize: size)
+        }
+        
+        return font
+    }
+}

--- a/GraceLog/Source/Util/Font/FontStylable.swift
+++ b/GraceLog/Source/Util/Font/FontStylable.swift
@@ -1,0 +1,14 @@
+//
+//  FontStylable.swift
+//  GraceLog
+//
+//  Created by 이건준 on 6/16/25.
+//
+
+import UIKit
+
+protocol FontStylable {
+    var fontName: FontName { get }
+    var fontStyle: FontStyle { get }
+    var font: UIFont { get }
+}

--- a/GraceLog/Source/Util/Font/GLFont.swift
+++ b/GraceLog/Source/Util/Font/GLFont.swift
@@ -1,0 +1,105 @@
+//
+//  GLFont.swift
+//  GraceLog
+//
+//  Created by 이건준 on 6/16/25.
+//
+
+import UIKit
+
+enum GLFont: FontStylable {
+    /// Pretendard-Bold
+    case bold12
+    case bold14
+    case bold15
+    case bold16
+    case bold17
+    case bold18
+    case bold20
+    
+    /// Pretendard-ExtraBold
+    case extraBold18
+    
+    /// Pretendard-SemiBold
+    case semiBold16
+    
+    /// Pretendard-Regular
+    case regular10
+    case regular11
+    case regular12
+    case regular14
+    case regular15
+    case regular16
+    case regular18
+    case regular24
+    
+    /// Pretendard-Medium
+    case medium10
+    
+    /// Pretendard-Light
+    case light11
+    
+    var fontName: FontName { .pretendard }
+    
+    var fontStyle: FontStyle {
+        switch self {
+        case .bold12, .bold14, .bold15, .bold16, .bold17, .bold18, .bold20:
+            return .bold
+        case .extraBold18:
+            return .extraBold
+        case .semiBold16:
+            return .semiBold
+        case .regular10, .regular11, .regular12, .regular14, .regular15, .regular16, .regular18, .regular24:
+            return .regular
+        case .medium10:
+            return .medium
+        case .light11:
+            return .light
+        }
+    }
+    
+    var font: UIFont {
+        switch self {
+        case .bold12:
+            return .customFont(font: .pretendard, style: fontStyle, size: 12)
+        case .bold14:
+            return .customFont(font: .pretendard, style: fontStyle, size: 14)
+        case .bold15:
+            return .customFont(font: .pretendard, style: fontStyle, size: 15)
+        case .bold16:
+            return .customFont(font: .pretendard, style: fontStyle, size: 16)
+        case .bold17:
+            return .customFont(font: .pretendard, style: fontStyle, size: 17)
+        case .bold18:
+            return .customFont(font: .pretendard, style: fontStyle, size: 18)
+        case .bold20:
+            return .customFont(font: .pretendard, style: fontStyle, size: 20)
+        case .extraBold18:
+            return .customFont(font: .pretendard, style: fontStyle, size: 18)
+        case .semiBold16:
+            return .customFont(font: .pretendard, style: fontStyle, size: 16)
+        case .regular10:
+            return .customFont(font: .pretendard, style: fontStyle, size: 10)
+        case .regular11:
+            return .customFont(font: .pretendard, style: fontStyle, size: 11)
+        case .regular12:
+            return .customFont(font: .pretendard, style: fontStyle, size: 12)
+        case .regular14:
+            return .customFont(font: .pretendard, style: fontStyle, size: 14)
+        case .regular15:
+            return .customFont(font: .pretendard, style: fontStyle, size: 15)
+        case .regular16:
+            return .customFont(font: .pretendard, style: fontStyle, size: 16)
+        case .regular18:
+            return .customFont(font: .pretendard, style: fontStyle, size: 18)
+        case .regular24:
+            return .customFont(font: .pretendard, style: fontStyle, size: 24)
+        case .medium10:
+            return .customFont(font: .pretendard, style: fontStyle, size: 10)
+        case .light11:
+            return .customFont(font: .pretendard, style: fontStyle, size: 11)
+        }
+    }
+    
+    
+}

--- a/GraceLog/Source/Util/UI/NavigationBarUtil.swift
+++ b/GraceLog/Source/Util/UI/NavigationBarUtil.swift
@@ -14,7 +14,7 @@ final class NavigationBarUtil {
         appearance.backgroundColor = .white
         appearance.titleTextAttributes = [
             .foregroundColor: UIColor.black,
-            .font: UIFont(name: "Pretendard-Bold", size: 17) ?? UIFont.boldSystemFont(ofSize: 17)
+            .font: GLFont.bold17.font
         ]
         appearance.largeTitleTextAttributes = [.foregroundColor: UIColor.black]
         


### PR DESCRIPTION
## 작업 내용

- [x] GraceLog프로젝트에서 사용될 `GLFont`구현
- [x] 이후 새로운 폰트 추가에 대한 확장성을 위한 `FontStylable`구현
- [x] 기존 `systemFont` -> `GLFont`로 변경

<br/><br/><br/>
## 고민점 및 해결 방법 (Optional)
#### 기존 폰트 적용 방법
``` swift
UIFont(name: "Pretendard-Medium", size: 10) ?? .systemFont(ofSize: 10)
```
- 기존 폰트 적용 시 위 코드와 같이 하드코딩됨
- 이후 폰트 변경 시 해당되는 모든 폰트를 변경되야함

#### 변경된 폰트 적용 방법
``` swift
GLFont.medium10.font

/// 커스텀 폰트 적용 예시
protocol FontStylable {
    var fontName: FontName { get }
    var fontStyle: FontStyle { get }
    var font: UIFont { get }
}

enum OswaldFont: FontStylable { ... }
``` 
- `GLFont`를 적용함으로써 해당 `medium10`에 대한 폰트정보만을 변경하면 전부 적용가능 
- `FontStylable`을 통해 `Pretendard`폰트 이외의 폰트를 적용할 시 확장 가능

<br/><br/><br/>
close: #
